### PR TITLE
fix incorrect variable usage for ServiceMonitor scrapeTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ helm install --name=kube-eagle kube-eagle/kube-eagle
 | `rbac.create`                     | Create and use role based access resources                         | `true`                |
 | `telemetry.host`                  | Host for prometheus server to to listen on                         | `0.0.0.0`             |
 | `telemetry.port`                  | Port for prometheus server to listen on                            | `8080`                |
-| `serviceMonitor.create`           | Whether or not to create a service monitor for prometheus operator | `false                |
+| `serviceMonitor.create`           | Whether or not to create a service monitor for prometheus operator | `false`               |
 | `serviceMonitor.interval`         | Scrape interval for prometheus operator                            | `10s`                 |
 | `serviceMonitor.scrapeTimeout`    | Scrape timeout for prometheus operator                             | `10s`                 |
 | `serviceMonitor.releaseLabel`     | Release label being used for prometheus operator selector          | `prometheus-operator` |

--- a/kube-eagle/Chart.yaml
+++ b/kube-eagle/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Prometheus exporter for Kubernetes pod & node resource requests, limits and usage.
 name: kube-eagle
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.1.0

--- a/kube-eagle/templates/servicemonitor.yaml
+++ b/kube-eagle/templates/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
   - interval: {{ .Values.serviceMonitor.interval }}
     port: http
     path: /metrics
-    scrapeTimeout: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   selector:
     matchLabels:
       app: {{ template "kube-eagle.name" . }}


### PR DESCRIPTION
The `spec.endpoints.*.scrapeTimeout` key was incorrectly using
`serviceMonitor.interval` instead of. Likely went unnoticed due to the
defaults being equal.