### PR TITLE
Updated README to fix old repo ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Helm chart for deployment of kube-eagle in Kubernetes.
 ## Installing helm chart
 
 ```bash
-helm repo add kube-eagle https://raw.githubusercontent.com/google-cloud-tools/kube-eagle-helm-chart/master
+helm repo add kube-eagle https://raw.githubusercontent.com/cloudworkz/kube-eagle-helm-chart/master
 helm repo update
 helm install --name=kube-eagle kube-eagle/kube-eagle
 ```


### PR DESCRIPTION
Moved ownership in the helm repo add command from google-cloud-tools (deprecated) to the new cloudworkz ownership.