### PR TITLE
Turn on honorLabels in service monitor

### DIFF
--- a/kube-eagle/templates/servicemonitor.yaml
+++ b/kube-eagle/templates/servicemonitor.yaml
@@ -23,6 +23,7 @@ spec:
     port: http
     path: /metrics
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    honorLabels: true
   selector:
     matchLabels:
       app: {{ template "kube-eagle.name" . }}


### PR DESCRIPTION
Turn on `honorLabels` in service monitor so metrics have correct namespace and pod set as suggested in https://github.com/cloudworkz/kube-eagle/issues/25#issuecomment-535971815