### PR TITLE
Add env variable in helm values

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ helm install --name=kube-eagle kube-eagle/kube-eagle
 | `containerSecurityContext`        | Security Context for the kube eagle container                      | `{}`                  |
 | `podAnnotations`                  | Pod annotations                                                    | `{}`                  |
 | `priorityClassName`               | Priority Class to be used by the pod                               | `""`                  |
+| `env`                             | Additional environment variables                                   | `{}`                  |

--- a/kube-eagle/templates/deployment.yaml
+++ b/kube-eagle/templates/deployment.yaml
@@ -51,6 +51,11 @@ spec:
               value: {{ .Values.metricsNamespace | quote }}
             - name: LOG_LEVEL
               value: {{ .Values.logLevel | quote }}
+{{- if .Values.env }}
+{{- with .Values.env }}
+    {{- toYaml . | nindent 12 }}
+{{- end }}
+{{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/kube-eagle/values.yaml
+++ b/kube-eagle/values.yaml
@@ -85,3 +85,12 @@ serviceMonitor:
   # different matchLabels configuration, to make sure it matches this ServiceMonitor.
   # If this is defined, the release label of the service monitor will match kube-eagle's one
   additionalLabels: 
+
+env: {}
+  # Add ability to include more opinionated environment variables
+  # - name: POD_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.podIP
+  # - name: SERVICE_8000_NAME
+  #   value: metrics-server-exporter 


### PR DESCRIPTION
 Add the ability to include more opinionated environment variables, like the ones required by [Gliderlabs consul registration](https://gliderlabs.github.io/registrator/latest/user/services/#ip-and-port)

```yaml
env:
  - name: POD_IP
    valueFrom:
      fieldRef:
        fieldPath: status.podIP
  - name: SERVICE_8000_NAME
    value: metrics-server-exporter
```

Relates to: https://github.com/cloudworkz/kube-eagle/pull/33