### PR TITLE
Add support for Kubernetes v1.16+

### DIFF
--- a/kube-eagle/templates/ingress.yaml
+++ b/kube-eagle/templates/ingress.yaml
@@ -1,7 +1,14 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "kube-eagle.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $newAPI := .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
+{{- if $newAPI -}}
+apiVersion: networking.k8s.io/v1
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
`extensions/v1beta1` were [marked deprecated in Kubernetes
v1.16](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/).

This enables support for newer versions of Kubernetes.